### PR TITLE
fix: remove theme change button

### DIFF
--- a/apps/nextjs/src/app/layout.tsx
+++ b/apps/nextjs/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { GeistMono } from "geist/font/mono";
 import { GeistSans } from "geist/font/sans";
 
 import { cn } from "@acme/ui";
-import { ThemeProvider, ThemeToggle } from "@acme/ui/theme";
+import { ThemeProvider } from "@acme/ui/theme";
 import { Toaster } from "@acme/ui/toast";
 
 import { TRPCReactProvider } from "~/trpc/react";
@@ -58,9 +58,9 @@ export default function RootLayout(props: { children: React.ReactNode }) {
           <ThirdwebProvider>
             <TRPCReactProvider>{props.children}</TRPCReactProvider>
           </ThirdwebProvider>
-          <div className="absolute bottom-4 right-4">
+          {/* <div className="absolute bottom-4 right-4">
             <ThemeToggle />
-          </div>
+          </div> */}
           <Toaster />
         </ThemeProvider>
       </body>


### PR DESCRIPTION
# Purpose

Remove the dark/light mode theme switch button

[PUMP-74](https://labrys-intern.atlassian.net/browse/PUMP-74?atlOrigin=eyJpIjoiOTI0NTYzYzA3M2VjNGYyNWIwMDdlZDhiZDYwYzg5MTMiLCJwIjoiaiJ9)

# Approach

Commented out the relevant code in case dark/light mode functionality is to be added later.


