### PR TITLE
Pump 71 projects pagination

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/layout.tsx
+++ b/apps/nextjs/src/app/(dashboard)/layout.tsx
@@ -17,7 +17,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     <>
       <div className="bg-custom-bg min-h-screen bg-cover bg-center">
         <Navbar />
-        <main>{children}</main>
+        <main className="pt-32">{children}</main>
       </div>
     </>
   );

--- a/apps/nextjs/src/app/(dashboard)/profile/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/profile/page.tsx
@@ -39,7 +39,7 @@ export default async function UserProfile() {
           alt="User Profile Icon"
           width={120}
           height={120}
-          className="mb-4 mt-36"
+          className="mb-4"
         />
 
         <div className="relative mb-4 flex h-auto justify-between gap-2">

--- a/apps/nextjs/src/app/(dashboard)/projects/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/projects/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useActiveAccount } from "thirdweb/react";
+import { Switch } from "@acme/ui/switch";
 
 import { Button } from "@acme/ui/button";
 import {
@@ -13,8 +14,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@acme/ui/dialog";
-import { Switch } from "@acme/ui/switch";
-
 import {
   Pagination,
   PaginationContent,
@@ -24,6 +23,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@acme/ui/pagination";
+
 
 import TrashIcon from "~/app/_components/_task/icons/TrashIcon";
 import { api } from "~/trpc/react";
@@ -50,7 +50,7 @@ export default function ProjectsPage() {
   // pagination
   const [currentPage, setCurrentPage] = useState(1);
   // number of projects per page
-  const projectsPerPage = 9; 
+  const projectsPerPage = 9;
 
   useEffect(() => {
     // Try to get wallet from activeAccount first
@@ -96,7 +96,9 @@ export default function ProjectsPage() {
   });
 
   // Calculate pagination
-  const totalPages = Math.ceil((filteredProjects?.length ?? 0) / projectsPerPage);
+  const totalPages = Math.ceil(
+    (filteredProjects?.length ?? 0) / projectsPerPage,
+  );
   const startIndex = (currentPage - 1) * projectsPerPage;
   const endIndex = startIndex + projectsPerPage;
   const currentProjects = filteredProjects?.slice(startIndex, endIndex);
@@ -230,45 +232,48 @@ export default function ProjectsPage() {
                       member.user === walletId && member.role === "Owner",
                   );
 
-                return (
-                  <div
-                    key={project._id.toString()}
-                    className="group relative flex min-h-32 cursor-pointer flex-col justify-between overflow-hidden rounded-lg border border-gray-700 bg-[#09090B] font-bold transition-colors hover:bg-[#18181B]"
-                    onClick={async () => {
-                      try {
-                        // Update active projects
-                        await updateActiveProjectsMutation.mutateAsync({
-                          walletId: walletId,
-                          projectId: project._id.toString(),
-                        });
+                  return (
+                    <div
+                      key={project._id.toString()}
+                      className="group relative flex min-h-32 cursor-pointer flex-col justify-between overflow-hidden rounded-lg border border-gray-700 bg-[#09090B] font-bold transition-colors hover:bg-[#18181B]"
+                      onClick={async () => {
+                        try {
+                          // Update active projects
+                          await updateActiveProjectsMutation.mutateAsync({
+                            walletId: walletId,
+                            projectId: project._id.toString(),
+                          });
 
-                        // Set the cookie
-                        document.cookie = `projectId=${project._id.toString()}; path=/;`;
+                          // Set the cookie
+                          document.cookie = `projectId=${project._id.toString()}; path=/;`;
 
-                        // Navigate to the project's tasks page
-                        router.push(`/tasks/${project._id.toString()}`);
-                      } catch (error) {
-                        console.error("Error updating active projects:", error);
-                        // Optionally, display an error message to the user
-                      }
-                      //document.cookie = `projectId=${project._id.toString()}; path=/;`;
-                      //router.push(`/tasks/${project._id.toString()}`);
-                      // router.refresh();
-                    }}
-                  >
-                    {isOwner && (
-                      <button
-                        className="absolute right-2 top-2 stroke-gray-500 opacity-0 transition-opacity duration-700 hover:stroke-rose-500 group-hover:opacity-100"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setProjectToDelete(project._id.toString());
-                          setIsDeleteModalOpen(true);
-                        }}
-                        aria-label="Delete Project"
-                      >
-                        <TrashIcon />
-                      </button>
-                    )}
+                          // Navigate to the project's tasks page
+                          router.push(`/tasks/${project._id.toString()}`);
+                        } catch (error) {
+                          console.error(
+                            "Error updating active projects:",
+                            error,
+                          );
+                          // Optionally, display an error message to the user
+                        }
+                        //document.cookie = `projectId=${project._id.toString()}; path=/;`;
+                        //router.push(`/tasks/${project._id.toString()}`);
+                        // router.refresh();
+                      }}
+                    >
+                      {isOwner && (
+                        <button
+                          className="absolute right-2 top-2 stroke-gray-500 opacity-0 transition-opacity duration-700 hover:stroke-rose-500 group-hover:opacity-100"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setProjectToDelete(project._id.toString());
+                            setIsDeleteModalOpen(true);
+                          }}
+                          aria-label="Delete Project"
+                        >
+                          <TrashIcon />
+                        </button>
+                      )}
 
                       <h3 className="p-4 text-white">{project.name}</h3>
                       <p className="px-4 pb-4 text-sm text-gray-400">
@@ -284,17 +289,29 @@ export default function ProjectsPage() {
                       <PaginationContent>
                         <PaginationItem>
                           <PaginationPrevious
-                            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                            className={currentPage === 1 ? "pointer-events-none opacity-50" : ""}
+                            onClick={() =>
+                              setCurrentPage((p) => Math.max(1, p - 1))
+                            }
+                            className={
+                              currentPage === 1
+                                ? "pointer-events-none opacity-50"
+                                : ""
+                            }
                           />
                         </PaginationItem>
-                        
+
                         {generatePaginationItems()}
 
                         <PaginationItem>
                           <PaginationNext
-                            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                            className={currentPage === totalPages ? "pointer-events-none opacity-50" : ""}
+                            onClick={() =>
+                              setCurrentPage((p) => Math.min(totalPages, p + 1))
+                            }
+                            className={
+                              currentPage === totalPages
+                                ? "pointer-events-none opacity-50"
+                                : ""
+                            }
                           />
                         </PaginationItem>
                       </PaginationContent>

--- a/apps/nextjs/src/app/(dashboard)/projects/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/projects/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useActiveAccount } from "thirdweb/react";
+import { Switch } from "@acme/ui/switch";
 
 import { Button } from "@acme/ui/button";
 import {
@@ -22,7 +23,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@acme/ui/pagination";
-import { Switch } from "@acme/ui/switch";
+
 
 import TrashIcon from "~/app/_components/_task/icons/TrashIcon";
 import { api } from "~/trpc/react";
@@ -83,16 +84,18 @@ export default function ProjectsPage() {
       },
     );
 
-  const filteredProjects = projects?.filter((project) => {
-    if (showFilter === "all") return true;
-    if (showFilter === "Owned")
-      return project.members.some(
-        (member) => member.walletId === walletId && member.role === "Owner",
-      );
-    if (showFilter === "my")
-      return project.members.some((member) => member.walletId === walletId);
-    return true;
-  })?.reverse(); // reverse here shows newest first
+  const filteredProjects = projects
+    ?.filter((project) => {
+      if (showFilter === "all") return true;
+      if (showFilter === "Owned")
+        return project.members.some(
+          (member) => member.walletId === walletId && member.role === "Owner",
+        );
+      if (showFilter === "my")
+        return project.members.some((member) => member.walletId === walletId);
+      return true;
+    })
+    .reverse(); // reverse here shows newest first
 
   // Calculate pagination
   const totalPages = Math.ceil(

--- a/apps/nextjs/src/app/(dashboard)/projects/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/projects/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useActiveAccount } from "thirdweb/react";
-import { Switch } from "@acme/ui/switch";
 
 import { Button } from "@acme/ui/button";
 import {
@@ -23,7 +22,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@acme/ui/pagination";
-
+import { Switch } from "@acme/ui/switch";
 
 import TrashIcon from "~/app/_components/_task/icons/TrashIcon";
 import { api } from "~/trpc/react";

--- a/apps/nextjs/src/app/(dashboard)/projects/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/projects/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useActiveAccount } from "thirdweb/react";
-import { Switch } from "@acme/ui/switch";
 
 import { Button } from "@acme/ui/button";
 import {
@@ -23,7 +22,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@acme/ui/pagination";
-
+import { Switch } from "@acme/ui/switch";
 
 import TrashIcon from "~/app/_components/_task/icons/TrashIcon";
 import { api } from "~/trpc/react";
@@ -93,7 +92,7 @@ export default function ProjectsPage() {
     if (showFilter === "my")
       return project.members.some((member) => member.walletId === walletId);
     return true;
-  });
+  })?.reverse(); // reverse here shows newest first
 
   // Calculate pagination
   const totalPages = Math.ceil(

--- a/apps/nextjs/src/app/(dashboard)/settings/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/settings/page.tsx
@@ -24,7 +24,7 @@ export default function Page() {
   const userData: UserClass | null = response as unknown as UserClass;
 
   return (
-    <section className="flex flex-col items-center justify-center gap-4 py-48">
+    <section className="flex flex-col items-center justify-center gap-4">
       <AccountSettings
         language={userData.userSettings?.language}
         theme={userData.userSettings?.isThemeDark}


### PR DESCRIPTION
# Purpose

Add pagination for the projects dashboard page to improve user experience by only displaying 9 projects on each page rather than all projects on one page. This helps deal with a large number of projects in future.

[PUMP-71](https://labrys-intern.atlassian.net/browse/PUMP-71?atlOrigin=eyJpIjoiYTQ3Zjk3MzdkMWIxNGY2MGIyNzgzODFiN2RhMjdjM2EiLCJwIjoiaiJ9)
# Approach

- Show 9 projects per page
- Only display pagination controls when there is more than one page of projects to display
- Maintain the filtering functionality for the projects while paginating 
- Show the newest projects first

Code: 
First, pagination state is setup with currentPage and fixed projectsPerPage(9). Then the total pages are calculated and the projects array is sliced to display on the current page. The pagination controls are rendered conditional (when totalPages required >1). 

## After Implementation:
<img width="1118" alt="Screenshot 2024-10-26 at 11 12 13 am" src="https://github.com/user-attachments/assets/c1cd54e1-14ef-4bf1-8d29-62ccad5e47be">


# Testing

- Pagination Visibility: <10 projects should not render pagination controls 
- Navigation functionality: previous button should be disabled on page 1 and next button should disable on last page
- Page numbers: should navigate successfully upon clicking and each page should only show 9 projects
