### PR TITLE
fix: only show public projects

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/projects/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/projects/page.tsx
@@ -85,7 +85,10 @@ export default function ProjectsPage() {
 
   const filteredProjects = projects
     ?.filter((project) => {
-      if (showFilter === "all") return true;
+      if (showFilter === "all") {
+        // Don't show private projects in "all" view
+        return !project.isPrivate;
+      }
       if (showFilter === "Owned")
         return project.members.some(
           (member) => member.walletId === walletId && member.role === "Owner",
@@ -230,7 +233,7 @@ export default function ProjectsPage() {
                 {currentProjects.map((project) => {
                   const isOwner = project.members.some(
                     (member) =>
-                      member.user === walletId && member.role === "Owner",
+                      member.walletId === walletId && member.role === "Owner",
                   );
 
                   return (


### PR DESCRIPTION
# Purpose

Only show public projects in the "All projects" view.

[PUMP-77](https://labrys-intern.atlassian.net/browse/PUMP-77?atlOrigin=eyJpIjoiOTg1NDdhM2Y5NGJjNDVlYzk0MDIxZWRkYTFiOTFiN2YiLCJwIjoiaiJ9)

# Approach

using the isPrivate boolean property of the project object in the filter.

# Testing

Create a new project as private (toggle) then check the "All projects" view.
