### PR TITLE
feat: added toast notification to tasks

### DIFF
--- a/apps/nextjs/src/app/_components/_task/new-task-card.tsx
+++ b/apps/nextjs/src/app/_components/_task/new-task-card.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 
 import type { NewTaskCard, ObjectIdString, TaskCard } from "@acme/validators";
+import { toast } from "@acme/ui/toast";
 
 // import type { taskCardSchema } from "./task-card-schema";
 import { api } from "~/trpc/react"; // Ensure you import your API hook
@@ -27,10 +28,12 @@ const NewTaskCard = ({
       console.log("Task created successfully");
       void utils.task.getTaskByStatusId.invalidate(); // Invalidate tasks and refresh data
       onTaskCreated(newTask); // Pass the new task back to the parent
+      toast.success(`Task ${newTask.title} created successfully`);
       // void utils.task.getStatusesByProjectId.invalidate();
     },
     onError: (error) => {
       console.error("Error creating task:", error);
+      toast.error("Error creating task");
     },
   }); // Initialize your mutation
 

--- a/apps/nextjs/src/app/_components/_task/task-card.tsx
+++ b/apps/nextjs/src/app/_components/_task/task-card.tsx
@@ -20,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@acme/ui/dialog";
+import { toast } from "@acme/ui/toast";
 
 import { api } from "~/trpc/react";
 import TrashIcon from "./icons/TrashIcon";
@@ -39,15 +40,18 @@ const TaskCard = ({ task, projectId, statusId }: TaskCardProps) => {
   const utils = api.useUtils();
 
   const deleteTask = api.task.deleteTask.useMutation({
-    onSuccess: () => {
+    onSuccess: (task) => {
       console.log("Task deleted successfully");
       void utils.task.getTaskByStatusId.invalidate();
+      toast.success(`Task ${task.task.title} deleted successfully`);
     },
     onError: (error) => {
       if (error instanceof Error) {
         console.error("Error deleting task:", error.message);
+        toast.error("Error deleting task");
       } else {
         console.error("Unknown error deleting task");
+        toast.error("Unknown error deleting task");
       }
     },
   });
@@ -57,9 +61,15 @@ const TaskCard = ({ task, projectId, statusId }: TaskCardProps) => {
       // Handle success
       console.log("Task updated successfully", updatedTask);
       void utils.task.getTaskByStatusId.invalidate(); // Invalidate tasks and refresh data
+      if (String(updatedTask.statusId) !== statusId) {
+        toast.success(`Task moved to new status`);
+      } else {
+        toast.success(`Task ${updatedTask.title} updated successfully`);
+      }
     },
     onError: (error) => {
       console.error("Error creating task:", error);
+      toast.error("Error creating task");
     },
   }); // Initialize your mutation
 


### PR DESCRIPTION
# Purpose

I have add the toast notifications to the tasks mutations

# Testing 
I wasn't able to add the status column that a task is changing to because we only store the id of status column on the task document not the status name.
