### PR TITLE
feat: tasks link set active in navbar

### DIFF
--- a/apps/nextjs/src/app/_components/_navbar/Navbar.tsx
+++ b/apps/nextjs/src/app/_components/_navbar/Navbar.tsx
@@ -90,7 +90,7 @@ export default async function Navbar() {
         {/* Navigation links */}
         <div className="top-24 z-40 flex flex-wrap border-b-2 bg-zinc-950">
           <NavLink href="/projects">Projects</NavLink>
-          <NavLink href="/tasks">Tasks</NavLink>
+          <NavLink href={`/tasks/${projectId}`}>Tasks</NavLink>
           <NavLink href="/profile">My Profile</NavLink>
           <NavLink href={projectId ? `/users/${projectId}` : "/missingproject"}>
             Users


### PR DESCRIPTION
I have update the navbar link component to set the task page active when are on a project.

# Testing

I tested this with a could of projects, know problem is that when you have no project selected that is gives 404 error. we need to address this in another issue.