### PR TITLE
Pump 86 badges navigation

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/profile/[walletId]/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/profile/[walletId]/page.tsx
@@ -39,7 +39,7 @@ export default async function UserProfile({
           className="mb-4"
         />
 
-        <div className="relative mb-4 flex h-auto justify-between">
+        <div className="relative mb-4 flex h-auto justify-between gap-2">
           <div className="w-7/10 justify-start" style={{ maxWidth: "70%" }}>
             <h1 className="text-2xl font-bold">{userData.name}</h1>
             <p className="w-96 flex-1 p-1 text-sm text-gray-400">
@@ -51,7 +51,7 @@ export default async function UserProfile({
               }
             </p>
           </div>
-          <div className="absolute bottom-0 right-0 flex h-10 w-full items-center justify-end rounded-lg border bg-gray-800 py-1 pl-7 text-sm sm:w-auto">
+          <div className="absolute bottom-0 right-0 flex h-10 w-full items-center justify-end rounded-lg border bg-gray-800 py-1 pl-4 text-sm sm:w-auto">
             <p>Copy {userData.name}'s wallet ID.</p>
             <CopyButton textToCopy={`${userData.walletId}`} />
           </div>

--- a/apps/nextjs/src/app/(dashboard)/profile/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/profile/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import Image from "next/image";
 
 import type { UserClass } from "@acme/db";
+import { toast } from "@acme/ui/toast";
 
 import { api } from "~/trpc/server";
 import BadgeSection from "../../_components/_profile/badgeSection";
@@ -14,8 +15,8 @@ export default async function UserProfile() {
   const walletId = cookies().get("wallet")?.value;
 
   if (!walletId) {
-    console.error("Wallet ID is undefined or not found in cookies.");
-    return <div>Error: Wallet ID not found.</div>;
+    toast.error("Wallet ID is undefined or not found.");
+    return;
   }
 
   const response = await api.user.byWallet({ walletId });

--- a/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
+++ b/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
@@ -136,6 +136,7 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
       </div>
     );
   }
+
   return (
     <div>
       <h1 className="text-3xl font-semibold">Badges Earned</h1>

--- a/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
+++ b/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
@@ -16,8 +16,16 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
     { image: string; title: string; count: number }[]
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [url, setUrl] = useState<string>("");
 
   const chain = defineChain(sepolia);
+
+  useEffect(() => {
+    const protocol = window.location.protocol;
+    const host = window.location.host;
+    const pathname = "/projects";
+    setUrl(`${protocol}//${host}${pathname}`);
+  }, []);
 
   useEffect(() => {
     const fetchNFTs = async () => {
@@ -95,7 +103,30 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
   }
 
   if (nfts.length === 0) {
-    return <div>No NFTs found.</div>;
+    return (
+      <div className="flex h-full flex-col">
+        <h1 className="text-3xl font-semibold">Badges Earned</h1>
+        <p className="mb-4 text-sm text-gray-400">
+          Complete tasks to earn badges. These badges represent your onchain
+          resume, they’re minted as NFTs on Sepolia Testnet using Thirdweb.
+        </p>
+        <p className="mb-4 text-sm">
+          You currently do not have any earned badges in your wallet.
+        </p>
+        <div className="mt-auto">
+          <p className="mb-4 text-sm">
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zesty-green"
+            >
+              Complete tasks in a project to earn badges.
+            </a>
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -103,7 +134,7 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
       <h1 className="text-3xl font-semibold">Badges Earned</h1>
       <p className="mb-4 text-sm text-gray-400">
         Complete tasks to earn badges. These badges represent your onchain
-        resume, they’re minted as NFTs on Sepolia Testnet.
+        resume, they’re minted as NFTs on Sepolia Testnet using Thirdweb.
       </p>
       <div className="flex flex-wrap gap-4">
         {nfts.map((nft, index) => (

--- a/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
+++ b/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
@@ -6,6 +6,8 @@ import { defineChain, getContract } from "thirdweb";
 import { sepolia } from "thirdweb/chains";
 import { balanceOf, getOwnedNFTs } from "thirdweb/extensions/erc1155";
 
+import { toast } from "@acme/ui/toast";
+
 import { client } from "~/app/thirdwebClient";
 import LoadingNFTs from "./loadingNFTs";
 
@@ -67,14 +69,14 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
         const nftData = await Promise.all(nftDataPromises);
 
         setNfts(nftData);
-      } catch (error) {
-        console.error("Error fetching NFTs: ", error);
+      } catch {
+        toast.error("Error fetching Badges:: ");
       } finally {
         setLoading(false);
       }
     };
 
-    fetchNFTs().catch((error) => console.error("Error fetching NFTs: ", error));
+    fetchNFTs().catch(() => toast.error("Error fetching NFTs: "));
   }, [chain, walletId]);
 
   if (!walletId) {
@@ -122,7 +124,7 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
                 alt="NFT Media"
                 width={150}
                 height={130}
-                onError={() => console.log(`Image not found: ${nft.image}`)}
+                onError={() => toast.error(`Image not found: ${nft.image}`)}
               />
             </div>
             <div className="relative border-t border-gray-700 bg-black bg-opacity-50 p-2">

--- a/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
+++ b/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
@@ -6,6 +6,15 @@ import { defineChain, getContract } from "thirdweb";
 import { sepolia } from "thirdweb/chains";
 import { balanceOf, getOwnedNFTs } from "thirdweb/extensions/erc1155";
 
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@acme/ui/dialog";
 import { toast } from "@acme/ui/toast";
 
 import { client } from "~/app/thirdwebClient";
@@ -13,7 +22,7 @@ import LoadingNFTs from "./loadingNFTs";
 
 const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
   const [nfts, setNfts] = useState<
-    { image: string; title: string; count: number }[]
+    { image: string; title: string; count: number; description: string }[]
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [url, setUrl] = useState<string>("");
@@ -71,6 +80,7 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
             title: ownedNFT.metadata.name ?? "NFT",
             image,
             count: Number(balance.toString()),
+            description: ownedNFT.metadata.description ?? "",
           };
         });
 
@@ -138,33 +148,65 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
       </p>
       <div className="flex flex-wrap gap-4">
         {nfts.map((nft, index) => (
-          <a
-            key={index}
-            href="https://basescan.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="m-1 block overflow-hidden rounded-lg border border-gray-700 shadow-lg transition-transform hover:border-gray-300"
-            style={{
-              width: "150px",
-              height: "225px",
-            }}
-          >
-            <div className="relative">
-              <Image
-                src={nft.image}
-                alt="NFT Media"
-                width={150}
-                height={130}
-                onError={() => toast.error(`Image not found: ${nft.image}`)}
-              />
-            </div>
-            <div className="relative border-t border-gray-700 bg-black bg-opacity-50 p-2">
-              <h3 className="inline-block text-lg font-bold">{nft.title}</h3>
-              <p className="absolute right-0 top-0 mr-2 mt-2 text-xs">
-                x{nft.count}
-              </p>
-            </div>
-          </a>
+          <Dialog key={index}>
+            <DialogTrigger asChild>
+              <button
+                className="m-1 block overflow-hidden rounded-lg border border-gray-700 shadow-lg transition-transform hover:border-gray-300"
+                style={{
+                  width: "150px",
+                  height: "225px",
+                }}
+              >
+                <div className="relative">
+                  <Image
+                    src={nft.image}
+                    alt="NFT Media"
+                    width={180}
+                    height={150}
+                    onError={() => toast.error(`Image not found: ${nft.image}`)}
+                  />
+                </div>
+                <div className="relative h-[75px] border-t border-gray-700 bg-black bg-opacity-50 p-2">
+                  <h3 className="block text-left text-lg font-bold">
+                    {nft.title}
+                  </h3>
+                  <p className="absolute right-0 top-0 mr-2 mt-2 text-xs">
+                    x{nft.count}
+                  </p>
+                </div>
+              </button>
+            </DialogTrigger>
+            <DialogContent className="flex max-h-[90vh] max-w-[600px] flex-col overflow-auto rounded-lg bg-black p-6 text-white">
+              <DialogHeader className="flex w-full items-start justify-center">
+                <DialogTitle className="text-2xl font-semibold">
+                  Badge Details
+                </DialogTitle>
+              </DialogHeader>
+              <div className="flex flex-col items-center">
+                <Image
+                  src={nft.image}
+                  alt="NFT Media"
+                  width={200}
+                  height={200}
+                  className="rounded-lg"
+                />
+                <h3 className="mt-4 text-lg font-bold">{nft.title}</h3>
+                <p className="mt-4 text-center text-sm text-gray-400">
+                  {nft.description}
+                </p>
+                <p className="mt-2 text-sm">
+                  You have earned this badge {nft.count} times.
+                </p>
+              </div>
+              <DialogFooter className="mt-4 flex justify-end gap-2">
+                <DialogClose asChild>
+                  <button className="bg-zesty-green rounded px-4 py-2 text-black">
+                    Close
+                  </button>
+                </DialogClose>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         ))}
       </div>
     </div>

--- a/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
+++ b/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
@@ -120,9 +120,7 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
           Complete tasks to earn badges. These badges represent your onchain
           resume, they’re minted as NFTs on Sepolia Testnet using Thirdweb.
         </p>
-        <p className="mb-4 text-sm">
-          You currently do not have any earned badges in your wallet.
-        </p>
+        <p className="mb-4 text-sm">There are currently no badges earned.</p>
         <div className="mt-auto">
           <p className="mb-4 text-sm">
             <a

--- a/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
+++ b/apps/nextjs/src/app/_components/_profile/badgeSection.tsx
@@ -103,7 +103,7 @@ const Badges: React.FC<{ walletId: string | undefined }> = ({ walletId }) => {
       <h1 className="text-3xl font-semibold">Badges Earned</h1>
       <p className="mb-4 text-sm text-gray-400">
         Complete tasks to earn badges. These badges represent your onchain
-        resume, they’re minted as NFTs on Base.
+        resume, they’re minted as NFTs on Sepolia Testnet.
       </p>
       <div className="flex flex-wrap gap-4">
         {nfts.map((nft, index) => (

--- a/apps/nextjs/src/app/_components/_task/task-card-dialog.tsx
+++ b/apps/nextjs/src/app/_components/_task/task-card-dialog.tsx
@@ -546,7 +546,6 @@ const TaskCardDialog = ({
                 onSubmit(newTaskData);
 
                 setIsDialogOpen(false);
-
               } else {
                 const updatedTaskData = {
                   ...taskData,
@@ -556,7 +555,6 @@ const TaskCardDialog = ({
                 onSubmit(updatedTaskData as TaskCard);
 
                 setIsDialogOpen(false);
-
               }
             })}
             className="bg-zesty-green hover:bg-zesty-green w-full text-black"


### PR DESCRIPTION
# Purpose

[PUMP-88](https://labrys-intern.atlassian.net/browse/PUMP-88?atlOrigin=eyJpIjoiOGVkYjM2NGFhMmI0NGVhNjk4NGFlYzBiYTYzNDZjZDkiLCJwIjoiaiJ9), [PUMP-89](https://labrys-intern.atlassian.net/browse/PUMP-89?atlOrigin=eyJpIjoiNzFmYmQwODI1MWIwNDQwM2FhY2VlZTRkNWVlYmQxYTQiLCJwIjoiaiJ9) & [PUMP-107](https://labrys-intern.atlassian.net/browse/PUMP-107?atlOrigin=eyJpIjoiN2FmNjYxZWM2NGIzNGUzNDk0YjZkNzA3ZGQ1YjU2YmIiLCJwIjoiaiJ9)

Combined three PUMP-Sprints into one.  

Updated description for badges earned in badge section.

Updated the messaged received when the user does not have any badges, also provided a link to /projects to allow ease for the user to start pumping tasks.

Change what happens when a badge is clicked.  When clicked, badges now will popup in a modal, containing the badge title, the amount of the badge the user has and a description of the badge.

# Approach

Used the styling previously used in task card dialog to create the style for the new modal.  Imported NFT data from thirdweb to display.

Used useEffect to allow for a client side link to a different webpage on the app that works for dev server and deployed server.


<img width="308" alt="image" src="https://github.com/user-attachments/assets/615f011e-2d94-4125-a13e-03836a9bf80d">

<img width="427" alt="image" src="https://github.com/user-attachments/assets/a619c733-2279-4cfc-950c-206bd6c810ac">

<img width="266" alt="image" src="https://github.com/user-attachments/assets/1e79f588-3b1d-4dfe-9051-63cfff68eedc">

