### PR TITLE
fix: horizontal scroller position

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/tasks/[projectId]/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/tasks/[projectId]/page.tsx
@@ -236,7 +236,7 @@ export default function TasksPage({
         items={statusColumns.map((column) => column._id)}
         strategy={horizontalListSortingStrategy}
       >
-        <div className="flex h-full flex-col">
+        <div className="flex h-[calc(100vh-12rem)] flex-col">
           <div className="relative flex items-center justify-center">
             <div className="mb-3 flex-1 justify-center">
               {isEditing && isOwner() ? (

--- a/apps/nextjs/src/app/_components/_task/new-status-column.tsx
+++ b/apps/nextjs/src/app/_components/_task/new-status-column.tsx
@@ -88,7 +88,7 @@ export default function NewStatusColumn({
       </DialogTrigger>
 
       {/* Dialog content for entering the new status */}
-      <DialogContent className="rounded-lg bg-gray-900 p-6 text-white">
+      <DialogContent className="rounded-lg bg-black p-6 text-white">
         <DialogHeader>
           <DialogTitle>Create New Status</DialogTitle>
         </DialogHeader>
@@ -115,7 +115,7 @@ export default function NewStatusColumn({
         <DialogFooter>
           <Button
             onClick={handleCreateStatus}
-            className="bg-zesty-green hover:bg-zesty-green rounded px-4 py-2 text-black hover:bg-opacity-80"
+            className="bg-zesty-green hover:bg-zesty-green w-full rounded px-4 py-2 text-black hover:bg-opacity-80"
           >
             Create Status
           </Button>


### PR DESCRIPTION
# Purpose

[PUMP-113](https://labrys-intern.atlassian.net/browse/PUMP-113?atlOrigin=eyJpIjoiNDExOTNjNGVmMTNjNDkwYmJiNmM3ZjE3MzA1MGZlZmYiLCJwIjoiaiJ9)

Move the horizontal scroll bar for tasks down to the bottom of the page and improve UI.

# Approach

Added a specific height calculation h-[calc(100vh-12rem)] to the outer container. This takes into account the navbar height and the padding-top.

# Testing

- Create/open a project with multiple status columns
